### PR TITLE
Cleanup docker bootstrapping and fact setting

### DIFF
--- a/playbooks/aws/openshift-cluster/config.yml
+++ b/playbooks/aws/openshift-cluster/config.yml
@@ -17,8 +17,5 @@
     g_ssh_user: "{{ hostvars.localhost.g_ssh_user_tmp }}"
     g_sudo: "{{ hostvars.localhost.g_sudo_tmp }}"
     g_nodeonmaster: true
-    openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: 2
-    openshift_deployment_type: "{{ deployment_type }}"
     openshift_hostname: "{{ ec2_private_ip_address }}"
     openshift_public_hostname: "{{ ec2_ip_address }}"

--- a/playbooks/byo/openshift-cluster/config.yml
+++ b/playbooks/byo/openshift-cluster/config.yml
@@ -5,6 +5,3 @@
     g_masters_group: "{{ 'masters' }}"
     g_nodes_group: "{{ 'nodes' }}"
     g_lb_group: "{{ 'lb' }}"
-    openshift_cluster_id: "{{ cluster_id | default('default') }}"
-    openshift_debug_level: 2
-    openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -2,12 +2,27 @@
 - include: evaluate_groups.yml
 
 - include: ../openshift-docker/config.yml
+  vars:
+    openshift_cluster_id: "{{ cluster_id | default('default') }}"
+    openshift_debug_level: "{{ debug_level | default(2) }}"
+    openshift_deployment_type: "{{ deployment_type }}"
 
 - include: ../openshift-etcd/config.yml
+  vars:
+    openshift_cluster_id: "{{ cluster_id | default('default') }}"
+    openshift_debug_level: "{{ debug_level | default(2) }}"
+    openshift_deployment_type: "{{ deployment_type }}"
 
 - include: ../openshift-master/config.yml
+  vars:
+    openshift_cluster_id: "{{ cluster_id | default('default') }}"
+    openshift_debug_level: "{{ debug_level | default(2) }}"
+    openshift_deployment_type: "{{ deployment_type }}"
 
 - include: ../openshift-node/config.yml
   vars:
+    openshift_cluster_id: "{{ cluster_id | default('default') }}"
+    openshift_debug_level: "{{ debug_level | default(2) }}"
+    openshift_deployment_type: "{{ deployment_type }}"
     osn_cluster_dns_domain: "{{ hostvars[groups.oo_first_master.0].openshift.dns.domain }}"
     osn_cluster_dns_ip: "{{ hostvars[groups.oo_first_master.0].cluster_dns_ip }}"

--- a/playbooks/common/openshift-cluster/scaleup.yml
+++ b/playbooks/common/openshift-cluster/scaleup.yml
@@ -6,7 +6,7 @@
     g_nodes_group: "{{ 'nodes' }}"
     g_lb_group: "{{ 'lb' }}"
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
-    openshift_debug_level: 2
+    openshift_debug_level: "{{ debug_level | default(2) }}"
     openshift_deployment_type: "{{ deployment_type }}"
 
 - include: ../openshift-node/config.yml

--- a/playbooks/common/openshift-docker/config.yml
+++ b/playbooks/common/openshift-docker/config.yml
@@ -1,69 +1,8 @@
-- name: Set facts necessary to configure docker
-  hosts:
-    - masters
-    - nodes
+- name: Configure docker hosts
+  hosts: oo_masters_to_config:oo_nodes_to_config:oo_etcd_to_config:oo_lb_to_config
+  vars:
+    docker_additional_registries: "{{ lookup('oo_option', 'docker_additional_registries') | oo_split }}"
+    docker_insecure_registries: "{{ lookup('oo_option',  'docker_insecure_registries') | oo_split }}"
+    docker_blocked_registries: "{{ lookup('oo_option', 'docker_blocked_registries') | oo_split }}"
   roles:
-  - openshift_facts
-  tasks:
-  - openshift_facts:
-      role: "{{ item.role }}"
-      local_facts: "{{ item.local_facts }}"
-    with_items:
-      - role: common
-        local_facts:
-          deployment_type: "{{ openshift_deployment_type }}"
-
-- name: Configure docker for additional repositories
-  hosts:
-    - masters
-    - nodes
-  handlers:
-    - name: restart docker
-      service: name=docker state=restarted
-  tasks:
-    # TODO -- currently this is sane to do on masters since we require
-    # that a master be part of the sdn which requires node and docker packages
-    # When we fix the SDN to work without a running node we should clean this up
-    - yum: name=docker state=installed
-    - stat: path=/etc/sysconfig/docker
-      register: docker_check
-    - set_fact:
-        docker_additional_registries: "{{ lookup('oo_option', 'docker_additional_registries')
-                                        | oo_split() | union(['registry.access.redhat.com'])
-                                        |  difference(['']) }}"
-      when: openshift.common.deployment_type in ['enterprise','atomic-enterprise','openshift-enterprise']
-    - set_fact:
-        docker_additional_registries: "{{ lookup('oo_option', 'docker_additional_registries')
-                                      | oo_split() | difference(['']) }}"
-      when: openshift.common.deployment_type not in ['enterprise','atomic-enterprise','openshift-enterprise']
-    - name: Add personal registries
-      lineinfile:
-        dest: /etc/sysconfig/docker
-        regexp: '^ADD_REGISTRY=.*$'
-        line: "ADD_REGISTRY='{{ docker_additional_registries
-                            | oo_prepend_strings_in_list('--add-registry ') | join(' ') }}'"
-      when: docker_check.stat.isreg and docker_additional_registries
-      notify:
-        - restart docker
-
-    - name: Block registries
-      lineinfile:
-        dest: /etc/sysconfig/docker
-        regexp: '^BLOCK_REGISTRY=.*$'
-        line: "BLOCK_REGISTRY='{{ lookup('oo_option', 'docker_blocked_registries') | oo_split()
-                              | oo_prepend_strings_in_list('--block-registry ') | join(' ') }}'"
-      when: docker_check.stat.isreg and
-          lookup('oo_option', 'docker_blocked_registries') != ''
-      notify:
-        - restart docker
-
-    - name: Grant access to additional insecure registries
-      lineinfile:
-        dest: /etc/sysconfig/docker
-        regexp: '^INSECURE_REGISTRY=.*'
-        line: "INSECURE_REGISTRY='{{ lookup('oo_option', 'docker_insecure_registries') | oo_split()
-                              | oo_prepend_strings_in_list('--insecure-registry ') | join(' ') }}'"
-      when: docker_check.stat.isreg and
-          lookup('oo_option', 'docker_insecure_registries') != ''
-      notify:
-        - restart docker
+  - openshift-docker

--- a/playbooks/common/openshift-docker/config.yml
+++ b/playbooks/common/openshift-docker/config.yml
@@ -5,4 +5,4 @@
     docker_insecure_registries: "{{ lookup('oo_option',  'docker_insecure_registries') | oo_split }}"
     docker_blocked_registries: "{{ lookup('oo_option', 'docker_blocked_registries') | oo_split }}"
   roles:
-  - openshift-docker
+  - openshift_docker

--- a/playbooks/common/openshift-docker/config.yml
+++ b/playbooks/common/openshift-docker/config.yml
@@ -5,4 +5,5 @@
     docker_insecure_registries: "{{ lookup('oo_option',  'docker_insecure_registries') | oo_split }}"
     docker_blocked_registries: "{{ lookup('oo_option', 'docker_blocked_registries') | oo_split }}"
   roles:
+  - openshift_facts
   - openshift_docker

--- a/playbooks/gce/openshift-cluster/config.yml
+++ b/playbooks/gce/openshift-cluster/config.yml
@@ -22,9 +22,6 @@
     g_ssh_user: "{{ hostvars.localhost.g_ssh_user_tmp }}"
     g_sudo: "{{ hostvars.localhost.g_sudo_tmp }}"
     g_nodeonmaster: true
-    openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: 2
-    openshift_deployment_type: "{{ deployment_type }}"
     openshift_hostname: "{{ gce_private_ip }}"
     openshift_use_openshift_sdn: "{{ hostvars.localhost.use_sdn  }}"
     os_sdn_network_plugin_name: "{{ hostvars.localhost.sdn_plugin }}"

--- a/playbooks/libvirt/openshift-cluster/config.yml
+++ b/playbooks/libvirt/openshift-cluster/config.yml
@@ -20,6 +20,3 @@
     g_nodes_group: "{{ 'tag_env-host-type-' ~ cluster_id ~ '-openshift-node' }}"
     g_ssh_user: "{{ hostvars.localhost.g_ssh_user_tmp }}"
     g_sudo: "{{ hostvars.localhost.g_sudo_tmp }}"
-    openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: 2
-    openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/openstack/openshift-cluster/config.yml
+++ b/playbooks/openstack/openshift-cluster/config.yml
@@ -15,7 +15,4 @@
     g_nodes_group: "{{ 'tag_env-host-type_' ~ cluster_id ~ '-openshift-node' }}"
     g_ssh_user: "{{ hostvars.localhost.g_ssh_user_tmp }}"
     g_sudo: "{{ hostvars.localhost.g_sudo_tmp }}"
-    openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: 2
-    openshift_deployment_type: "{{ deployment_type }}"
     openshift_hostname: "{{ ansible_default_ipv4.address }}"

--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -1,38 +1,33 @@
-Role Name
+Docker
 =========
 
-A brief description of the role goes here.
+TODO
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+TODO
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+TODO
 
 Dependencies
 ------------
 
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+TODO
 
 Example Playbook
 ----------------
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
-
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
+TODO
 
 License
 -------
 
-BSD
+Apache License, Version 2.0
 
 Author Information
 ------------------
-
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+Kenny Woodson

--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Restart Docker
+- name: restart docker
   service:
     name: docker
     state: restarted

--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -1,4 +1,7 @@
 ---
 
-- name: restart docker
-  service: name=docker state=restarted
+- name: Restart Docker
+  service:
+    name: docker
+    state: restarted
+  when: not docker_service_status_changed | default(false)

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,9 +1,17 @@
 ---
 # tasks file for docker
 - name: Install docker
-  yum: pkg=docker
+  yum:
+    pkg: docker
   when: not openshift.common.is_atomic | bool
 
 - name: enable and start the docker service
-  service: name=docker enabled=yes state=started
+  service:
+    name: docker
+    enabled: yes
+    state: started
+  register: start_result
+
+- set_fact:
+    docker_service_status_changed = start_result | changed
 

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -11,10 +11,15 @@
   yum: pkg=etcd-2.* state=present
   when: not openshift.common.is_containerized | bool
 
-- name: Pull etcd container
-  command: >
-    docker pull {{ openshift.etcd.etcd_image }}
+- name: Get docker images
+  command: docker images
+  changed_when: false
   when: openshift.common.is_containerized | bool
+  register: docker_images
+
+- name: Pull etcd container
+  command: docker pull {{ openshift.etcd.etcd_image }}
+  when: openshift.common.is_containerized | bool and openshift.etcd.etcd_image not in docker_images.stdout
 
 - name: Install etcd container service file
   template:

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -7,9 +7,6 @@
     msg: IPv4 address not found for {{ etcd_interface }}
   when: "'ipv4' not in hostvars[inventory_hostname]['ansible_' ~ etcd_interface] or 'address' not in hostvars[inventory_hostname]['ansible_' ~ etcd_interface].ipv4"
 
-- debug: var=openshift.common.is_containerized
-- debug: var=openshift.common.is_atomic
-
 - name: Install etcd
   yum: pkg=etcd-2.* state=present
   when: not openshift.common.is_containerized | bool
@@ -25,14 +22,14 @@
     src: etcd.docker.service
   register: install_etcd_result
   when: openshift.common.is_containerized | bool
-  
+
 - name: Ensure etcd datadir exists
   when: openshift.common.is_containerized | bool
   file:
     path: "{{ etcd_data_dir }}"
     state: directory
     mode: 0700
-  
+
 
 - name: Disable system etcd when containerized
   when: openshift.common.is_containerized | bool

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -46,16 +46,16 @@
   file:
     path: "{{ etcd_conf_dir }}"
     state: directory
-    owner: etcd
-    group: etcd
+    owner: "{{ 'etcd' if not openshift.common.is_containerized | bool else omit }}"
+    group: "{{ 'etcd' if not openshift.common.is_containerized | bool else omit }}"
     mode: 0700
 
 - name: Validate permissions on certificate files
   file:
     path: "{{ item }}"
     mode: 0600
-    group: etcd
-    owner: etcd
+    owner: "{{ 'etcd' if not openshift.common.is_containerized | bool else omit }}"
+    group: "{{ 'etcd' if not openshift.common.is_containerized | bool else omit }}"
   when: etcd_url_scheme == 'https'
   with_items:
   - "{{ etcd_ca_file }}"
@@ -66,8 +66,8 @@
   file:
     path: "{{ item }}"
     mode: 0600
-    group: etcd
-    owner: etcd
+    owner: "{{ 'etcd' if not openshift.common.is_containerized | bool else omit }}"
+    group: "{{ 'etcd' if not openshift.common.is_containerized | bool else omit }}"
   when: etcd_peer_url_scheme == 'https'
   with_items:
   - "{{ etcd_peer_ca_file }}"

--- a/roles/openshift_docker/meta/main.yml
+++ b/roles/openshift_docker/meta/main.yml
@@ -1,8 +1,8 @@
 ---
 galaxy_info:
-  author: Kenny Woodson
-  description: Docker
-  company: Red Hat, Inc
+  author: Jason DeTiberus
+  description: OpenShift Docker
+  company: Red Hat, Inc.
   license: Apache License, Version 2.0
   min_ansible_version: 1.9
   platforms:
@@ -11,4 +11,6 @@ galaxy_info:
     - 7
   categories:
   - cloud
-dependencies: []
+dependencies:
+- { role: openshift_common }
+- { role: docker }

--- a/roles/openshift_docker/tasks/main.yml
+++ b/roles/openshift_docker/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- openshift_facts:
+  - role: common
+    local_facts:
+      deployment_type: "{{ openshift_deployment_type }}"
+      docker_additional_registries: "{{ docker_additional_registries | oo_split() }}"
+      docker_insecure_registries: "{{ docker_insecure_registries | oo_split() }}"
+      docker_blocked_registries: "{{ docker_blocked_registries | oo_split() }}"
+
+- name: Set registry params
+  lineinfile:
+    dest: /etc/sysconfig/docker
+    regexp: '^{{ reg_conf_var }}=.*$'
+    line: "{{ reg_conf_var }}='{{ reg_fact_val | oo_prepend_strings_in_list(reg_flag ~ ' ') | join(' ') }}'"
+  when: "'docker_additional_registries' in openshift.common"
+  with_items:
+  - reg_conf_var: ADD_REGISTRY
+    reg_fact_val: {{ openshift.common.docker_additional_registries }}
+    reg_flag: --add-registry
+  - reg_conf_var: BLOCK_REGISTRY
+    reg_fact_val: {{ openshift.common.docker_blocked_registries }}
+    reg_flag: --block-registry
+  - reg_conf_var: INSECURE_REGISTRY
+    reg_fact_val: {{ openshift.common.docker_insecure_registries }}
+    reg_flag: --insecure-registry
+  notify:
+  - restart docker

--- a/roles/openshift_docker/tasks/main.yml
+++ b/roles/openshift_docker/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
+- debug: var=docker_additional_registries
+- debug: var=docker_blocked_registries
+- debug: var=docker_insecure_registries
 - openshift_facts:
-  - role: common
+    role: common
     local_facts:
       deployment_type: "{{ openshift_deployment_type }}"
       docker_additional_registries: "{{ docker_additional_registries | oo_split() }}"
@@ -15,13 +18,13 @@
   when: "'docker_additional_registries' in openshift.common"
   with_items:
   - reg_conf_var: ADD_REGISTRY
-    reg_fact_val: {{ openshift.common.docker_additional_registries }}
+    reg_fact_val: "{{ openshift.common.docker_additional_registries }}"
     reg_flag: --add-registry
   - reg_conf_var: BLOCK_REGISTRY
-    reg_fact_val: {{ openshift.common.docker_blocked_registries }}
+    reg_fact_val: "{{ openshift.common.docker_blocked_registries }}"
     reg_flag: --block-registry
   - reg_conf_var: INSECURE_REGISTRY
-    reg_fact_val: {{ openshift.common.docker_insecure_registries }}
+    reg_fact_val: "{{ openshift.common.docker_insecure_registries }}"
     reg_flag: --insecure-registry
   notify:
   - restart docker

--- a/roles/openshift_docker/tasks/main.yml
+++ b/roles/openshift_docker/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-- debug: var=docker_additional_registries
-- debug: var=docker_blocked_registries
-- debug: var=docker_insecure_registries
 - openshift_facts:
     role: common
     local_facts:
@@ -13,8 +10,8 @@
 - name: Set registry params
   lineinfile:
     dest: /etc/sysconfig/docker
-    regexp: '^{{ reg_conf_var }}=.*$'
-    line: "{{ reg_conf_var }}='{{ reg_fact_val | oo_prepend_strings_in_list(reg_flag ~ ' ') | join(' ') }}'"
+    regexp: '^{{ item.reg_conf_var }}=.*$'
+    line: "{{ item.reg_conf_var }}='{{ item.reg_fact_val | oo_prepend_strings_in_list(item.reg_flag ~ ' ') | join(' ') }}'"
   when: "'docker_additional_registries' in openshift.common"
   with_items:
   - reg_conf_var: ADD_REGISTRY

--- a/roles/openshift_docker/tasks/main.yml
+++ b/roles/openshift_docker/tasks/main.yml
@@ -6,9 +6,9 @@
     role: common
     local_facts:
       deployment_type: "{{ openshift_deployment_type }}"
-      docker_additional_registries: "{{ docker_additional_registries | oo_split() }}"
-      docker_insecure_registries: "{{ docker_insecure_registries | oo_split() }}"
-      docker_blocked_registries: "{{ docker_blocked_registries | oo_split() }}"
+      docker_additional_registries: "{{ docker_additional_registries }}"
+      docker_insecure_registries: "{{ docker_insecure_registries }}"
+      docker_blocked_registries: "{{ docker_blocked_registries }}"
 
 - name: Set registry params
   lineinfile:

--- a/roles/openshift_examples/defaults/main.yml
+++ b/roles/openshift_examples/defaults/main.yml
@@ -1,14 +1,14 @@
 ---
 # By default install rhel and xpaas streams on enterprise installs
-openshift_examples_load_centos: "{{ openshift_deployment_type not in ['enterprise','openshift-enterprise','atomic-enterprise','online'] }}"
-openshift_examples_load_rhel: "{{ openshift_deployment_type in ['enterprise','openshift-enterprise','atomic-enterprise','online'] }}"
+openshift_examples_load_centos: "{{ openshift_deployment_type == 'origin' }}"
+openshift_examples_load_rhel: "{{ openshift_deployment_type != 'origin' }}"
 openshift_examples_load_db_templates: true
-openshift_examples_load_xpaas: "{{ openshift_deployment_type in ['enterprise','openshift-enterprise','atomic-enterprise','online']  }}"
+openshift_examples_load_xpaas: "{{ openshift_deployment_type != 'origin' }}"
 openshift_examples_load_quickstarts: true
 
 content_version: "{{ 'v1.1' if openshift.common.version_greater_than_3_1_or_1_1 else 'v1.0' }}"
 
-examples_base: "{% if openshift.common.is_atomic %}{{ openshift.common.config_base }}{% else %}/usr/share/openshift{% endif %}/examples"
+examples_base: "{{ openshift.common.config_base if openshift.common.is_containerized else '/usr/share/openshift' }}/examples"
 image_streams_base: "{{ examples_base }}/image-streams"
 centos_image_streams: "{{ image_streams_base}}/image-streams-centos7.json"
 rhel_image_streams: "{{ image_streams_base}}/image-streams-rhel7.json"

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -970,6 +970,69 @@ def get_local_facts_from_file(filename):
     return local_facts
 
 
+def set_container_facts_if_unset(facts):
+    """ Set containerized facts.
+
+        Args:
+            facts (dict): existing facts
+        Returns:
+            dict: the facts dict updated with the generated containerization
+            facts
+    """
+    deployment_type = facts['common']['deployment_type']
+    if deployment_type in ['enterprise', 'openshift-enterprise']:
+        master_image = 'openshift3/ose'
+        cli_image = master_image
+        node_image = 'openshift3/node'
+        ovs_image = 'openshift3/openvswitch'
+        etcd_image = 'registry.access.redhat.com/rhel7/etcd'
+    elif deployment_type == 'atomic-enterprise':
+        master_image = 'aep3_beta/aep'
+        cli_image = master_image
+        node_image = 'aep3_beta/node'
+        ovs_image = 'aep3_beta/openvswitch'
+        etcd_image = 'registry.access.redhat.com/rhel7/etcd'
+    else:
+        master_image = 'openshift/origin'
+        cli_image = master_image
+        node_image = 'openshift/node'
+        ovs_image = 'openshift/openvswitch'
+        etcd_image = 'registry.access.redhat.com/rhel7/etcd'
+
+    facts['common']['is_atomic'] = os.path.isfile('/run/ostree-booted')
+    if 'is_containerized' not in facts['common']:
+        facts['common']['is_containerized'] = facts['common']['is_atomic']
+    if 'cli_image' not in facts['common']:
+        facts['common']['cli_image'] = cli_image
+    if 'etcd' in facts and 'etcd_image' not in facts['etcd']:
+        facts['etcd']['etcd_image'] = etcd_image
+    if 'master' in facts and 'master_image' not in facts['master']:
+        facts['master']['master_image'] = master_image
+    if 'node' in facts:
+        if 'node_image' not in facts['node']:
+            facts['node']['node_image'] = node_image
+        if 'ovs_image' not in facts['node']:
+            facts['node']['ovs_image'] = ovs_image
+
+    # shared /tmp/openshift vol is for file exchange with ansible
+    # --privileged is required to read the config dir
+    # --net host to access openshift from the container
+    # maybe -v /var/run/docker.sock:/var/run/docker.sock is required as well
+    runner = ("docker run --rm --privileged --net host -v "
+              "/tmp/openshift:/tmp/openshift -v {datadir}:{datadir} "
+              "-v {confdir}:{confdir} "
+              "-e KUBECONFIG={confdir}/master/admin.kubeconfig "
+              "{image}").format(confdir=facts['common']['config_base'],
+                                datadir=facts['common']['data_dir'],
+                                image=facts['common']['cli_image'])
+
+    if facts['common']['is_containerized']:
+        facts['common']['client_binary'] = '%s cli' % runner
+        facts['common']['admin_binary'] = '%s admin' % runner
+
+    return facts
+
+
 class OpenShiftFactsUnsupportedRoleError(Exception):
     """Origin Facts Unsupported Role Error"""
     pass
@@ -1047,7 +1110,7 @@ class OpenShiftFacts(object):
         facts = set_version_facts_if_unset(facts)
         facts = set_aggregate_facts(facts)
         facts = set_etcd_facts_if_unset(facts)
-        facts = self.set_containerized_facts_if_unset(facts)
+        facts = set_container_facts_if_unset(facts)
         return dict(openshift=facts)
 
     def get_defaults(self, roles):
@@ -1214,56 +1277,6 @@ class OpenShiftFacts(object):
 
         self.changed = changed
         return new_local_facts
-
-    def set_containerized_facts_if_unset(self, facts):
-        deployment_type = facts['common']['deployment_type']
-        if deployment_type in ['enterprise','openshift-enterprise']:
-            master_image = 'openshift3/ose'
-            cli_image = master_image
-            node_image = 'openshift3/node'
-            ovs_image = 'openshift3/openvswitch'
-            etcd_image = 'registry.access.redhat.com/rhel7/etcd'
-        elif deployment_type == 'atomic-enterprise':
-            master_image = 'aep3_beta/aep'
-            cli_image = master_image
-            node_image = 'aep3_beta/node'
-            ovs_image = 'aep3_beta/openvswitch'
-            etcd_image = 'registry.access.redhat.com/rhel7/etcd'
-        else:
-            master_image = 'openshift/origin'
-            cli_image = master_image
-            node_image = 'openshift/node'
-            ovs_image = 'openshift/openvswitch'
-            etcd_image = 'registry.access.redhat.com/rhel7/etcd'
-
-        facts['common']['is_atomic'] = os.path.isfile('/run/ostree-booted')
-        if 'is_containerized' not in facts['common']:
-            facts['common']['is_containerized'] = facts['common']['is_atomic']
-        if 'cli_image' not in facts['common']:
-            facts['common']['cli_image'] = cli_image
-        if 'master' in facts:
-            if 'master_image' not in facts['master']:
-                facts['master']['master_image'] = master_image
-        if 'node' in facts:
-            if 'node_image' not in facts ['node']:
-                facts['node']['node_image'] = node_image
-            if 'ovs_image' not in facts ['node']:
-                facts['node']['ovs_image'] = ovs_image
-        if 'etcd' in facts:
-            if 'etcd_image' not in facts['etcd']:
-                facts['etcd']['etcd_image'] = etcd_image
-
-        # shared /tmp/openshift vol is for file exchange with ansible
-        # --privileged is required to read the config dir
-        # --net host to access openshift from the container
-        # maybe -v /var/run/docker.sock:/var/run/docker.sock is required as well
-        runner = "docker run --rm --privileged --net host -v /tmp/openshift:/tmp/openshift -v {datadir}:{datadir} -v {confdir}:{confdir} -e KUBECONFIG={confdir}/master/admin.kubeconfig {image}".format(confdir=facts['common']['config_base'], datadir=facts['common']['data_dir'], image=facts['common']['cli_image'])
-
-        if facts['common']['is_containerized']:
-            facts['common']['client_binary'] = '%s cli' % runner
-            facts['common']['admin_binary'] = '%s admin' % runner
-
-        return facts
 
 
 def main():

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -647,7 +647,7 @@ def set_deployment_facts_if_unset(facts):
         for cat in  ['additional', 'blocked', 'insecure']:
             key = 'docker_{0}_registries'.format(cat)
             if key in facts['common']:
-                facts['common'][key] = set(facts['common'][key]) - set([''])
+                facts['common'][key] = list(set(facts['common'][key]) - set(['']))
 
 
         if deployment_type in ['enterprise', 'atomic-enterprise', 'openshift-enterprise']:

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -934,6 +934,7 @@ def save_local_facts(filename, facts):
             os.makedirs(fact_dir)
         with open(filename, 'w') as fact_file:
             fact_file.write(module.jsonify(facts))
+        os.chmod(filename, 0o600)
     except (IOError, OSError) as ex:
         raise OpenShiftFactsFileWriteError(
             "Could not create fact file: %s, error: %s" % (filename, ex)

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -643,6 +643,20 @@ def set_deployment_facts_if_unset(facts):
                 data_dir = '/var/lib/openshift'
             facts['common']['data_dir'] = data_dir
 
+        # remove duplicate and empty strings from registry lists
+        for cat in  ['additional', 'blocked', 'insecure']:
+            key = 'docker_{0}_registries'.format(cat)
+            if key in facts['common']:
+                facts['common'][key] = set(facts['common'][key]) - set([''])
+
+
+        if deployment_type in ['enterprise', 'atomic-enterprise', 'openshift-enterprise']:
+            addtl_regs = facts['common']['docker_additional_registries']:
+            ent_reg = 'registry.access.redhat.com'
+            if ent_reg not in addtl_regs
+                facts['common']['docker_additional_registries'].append(ent_reg)
+
+
     for role in ('master', 'node'):
         if role in facts:
             deployment_type = facts['common']['deployment_type']
@@ -1220,7 +1234,7 @@ class OpenShiftFacts(object):
             node_image = 'openshift/node'
             ovs_image = 'openshift/openvswitch'
             etcd_image = 'registry.access.redhat.com/rhel7/etcd'
-        
+
         facts['common']['is_atomic'] = os.path.isfile('/run/ostree-booted')
         if 'is_containerized' not in facts['common']:
             facts['common']['is_containerized'] = facts['common']['is_atomic']
@@ -1237,7 +1251,7 @@ class OpenShiftFacts(object):
         if 'etcd' in facts:
             if 'etcd_image' not in facts['etcd']:
                 facts['etcd']['etcd_image'] = etcd_image
-        
+
         # shared /tmp/openshift vol is for file exchange with ansible
         # --privileged is required to read the config dir
         # --net host to access openshift from the container

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -651,10 +651,10 @@ def set_deployment_facts_if_unset(facts):
 
 
         if deployment_type in ['enterprise', 'atomic-enterprise', 'openshift-enterprise']:
-            addtl_regs = facts['common']['docker_additional_registries']:
+            addtl_regs = facts['common'].get('docker_additional_registries', [])
             ent_reg = 'registry.access.redhat.com'
-            if ent_reg not in addtl_regs
-                facts['common']['docker_additional_registries'].append(ent_reg)
+            if ent_reg not in addtl_regs:
+                facts['common']['docker_additional_registries'] = addtl_regs.append(ent_reg)
 
 
     for role in ('master', 'node'):

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -11,5 +11,8 @@
   with_items:
     - PyYAML
 
-- name: Gather Cluster facts
+- name: Gather Cluster facts and set is_containerized if needed
   openshift_facts:
+    role: common
+    local_facts:
+      is_containerized: "{{ openshift_containerized | default(None) }}"

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -5,6 +5,7 @@
   until: omd_get_node.rc == 0
   retries: 20
   delay: 5
+  changed_when: false
   with_items: openshift_nodes
 
 - name: Set node schedulability

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -83,12 +83,16 @@
   register: install_result
   when: not openshift.common.is_containerized | bool
 
-# TODO: enable when ansible#1993 lands and is widespread enough
-# - name: Docker image present
-#   docker:
-#     image: "{{ openshift.common.docker.image }}"
-#     state: image_present
-#   when: openshift.common.is_containerized | bool
+- name: Get docker images
+  command: docker images
+  changed_when: false
+  when: openshift.common.is_containerized | bool
+  register: docker_images
+
+- name: Pull required docker image
+  command: >
+    docker pull {{ openshift.master.master_image }}
+  when: openshift.common.is_containerized | bool and openshift.master.master_image not in docker_images.stdout
 
 - name: Install Master docker service file
   template:

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -315,6 +315,7 @@
 
 - name: Lookup default group for ansible_ssh_user
   command: "/usr/bin/id -g {{ ansible_ssh_user }}"
+  changed_when: false
   register: _ansible_ssh_user_gid
 
 - name: Create the client config dir(s)

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -193,7 +193,7 @@
     src: atomic-openshift-master-controllers.j2
     dest: /etc/sysconfig/{{ openshift.common.service_type }}-master-controllers
     force: no
-  when: openshift_master_ha | bool and openshift_master_cluster_method == "native"  
+  when: openshift_master_ha | bool and openshift_master_cluster_method == "native"
 - command: systemctl daemon-reload
   when: openshift_master_ha | bool and openshift_master_cluster_method == "native"
 # end workaround for missing systemd unit files
@@ -264,7 +264,7 @@
   service: name={{ openshift.common.service_type }}-master enabled=yes state=started
   when: not openshift_master_ha | bool
   register: start_result
-  
+
 - name: Stop and disable non HA master when running HA
   service: name={{ openshift.common.service_type }}-master enabled=no state=stopped
   when: openshift_master_ha | bool

--- a/roles/openshift_master/templates/master.docker.service.j2
+++ b/roles/openshift_master/templates/master.docker.service.j2
@@ -5,7 +5,7 @@ Requires=docker.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/{{ openshift.common.service_type }}-master
-ExecStartPre=-/usr/bin/docker rm -f {{ openshift.common.service_type}}-master
+ExecStartPre=-/usr/bin/docker rm -f {{ openshift.common.service_type }}-master
 ExecStart=/usr/bin/docker run --rm --privileged --net=host --name {{ openshift.common.service_type }}-master -v {{ openshift.common.data_dir }}:{{ openshift.common.data_dir }} -v /var/run/docker.sock:/var/run/docker.sock -v {{ openshift.common.config_base }}:{{ openshift.common.config_base }} {{ openshift.master.master_image }} start master --config=${CONFIG_FILE} $OPTIONS
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop {{ openshift.common.service_type }}-master

--- a/roles/openshift_master_ca/tasks/main.yml
+++ b/roles/openshift_master_ca/tasks/main.yml
@@ -12,11 +12,17 @@
   file:
     path: "{{ openshift_master_config_dir }}"
     state: directory
-    
+
+- name: Get docker images
+  command: docker images
+  changed_when: false
+  when: openshift.common.is_containerized | bool
+  register: docker_images
+
 - name: Pull required docker image
   command: >
     docker pull {{ openshift.common.cli_image }}
-  when: openshift.common.is_containerized | bool
+  when: openshift.common.is_containerized | bool and openshift.common.cli_image not in docker_images.stdout
 
 - name: Create the master certificates if they do not already exist
   command: >

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -13,4 +13,3 @@ galaxy_info:
   - cloud
 dependencies:
 - { role: openshift_common }
-- { role: docker }

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -36,7 +36,7 @@
       storage_plugin_deps: "{{ osn_storage_plugin_deps | default(None) }}"
       node_image: "{{ osn_image | default(None) }}"
       ovs_image: "{{ osn_ovs_image | default(None) }}"
-      
+
 
 # We have to add tuned-profiles in the same transaction otherwise we run into depsolving
 # problems because the rpms don't pin the version properly. This was fixed in 3.1 packaging.
@@ -50,12 +50,28 @@
   register: sdn_install_result
   when: openshift.common.use_openshift_sdn and not openshift.common.is_containerized | bool
 
+- name: Get docker images
+  command: docker images
+  changed_when: false
+  when: openshift.common.is_containerized | bool
+  register: docker_images
+
+- name: Pull required docker image
+  command: >
+    docker pull {{ openshift.node.node_image }}
+  when: openshift.common.is_containerized | bool and openshift.node.node_image not in docker_images.stdout
+
 - name: Install Node docker service file
   template:
     dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
     src: openshift.docker.node.service
   register: install_node_result
   when: openshift.common.is_containerized | bool
+
+- name: Pull required docker image
+  command: >
+    docker pull {{ openshift.node.ovs_image }}
+  when: openshift.common.is_containerized | bool and openshift.node.ovs_image not in docker_images.stdout
 
 - name: Install OpenvSwitch docker service file
   template:

--- a/roles/openshift_serviceaccounts/tasks/main.yml
+++ b/roles/openshift_serviceaccounts/tasks/main.yml
@@ -21,6 +21,7 @@
 
 - name: Get current security context constraints
   shell: "{{ openshift.common.client_binary }} get scc privileged -o yaml > /tmp/openshift/scc.yaml"
+  changed_when: false
 
 - name: Add security context constraint for {{ item }}
   lineinfile:


### PR DESCRIPTION
Currently testing this, cleans up the docker settings quite a bit, might even be able to get rid of the openshift-docker playbook and require this role in the master, node, etc playbooks for containerized installs.
